### PR TITLE
Avoid Exception when no token is available.

### DIFF
--- a/src/MembersBundle/Twig/Extension/NavigationExtension.php
+++ b/src/MembersBundle/Twig/Extension/NavigationExtension.php
@@ -67,7 +67,7 @@ class NavigationExtension extends \Twig_Extension
     ): Container {
 
         $cacheKey = $cache;
-        $user = $this->tokenStorage->getToken()->getUser();
+        $user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
 
         if (!\Pimcore\Tool::isFrontendRequestByAdmin() && $cacheKey !== FALSE) {
 


### PR DESCRIPTION
In our current setup the navigation is not shown when the document is rendered as the 404 error page because the twig navigation extension throws an exception. When the page is accessed directly the navigation is rendered just fine.
This is caused by $this->tokenStorage->getToken() returning null instead of a token.
I have no idea why no token is available inside the 404 error handler.