### PR TITLE
Clearify when to install members

### DIFF
--- a/docs/300_CustomerDataFw.md
+++ b/docs/300_CustomerDataFw.md
@@ -27,3 +27,5 @@ members:
         adapter:
             class_name: 'MembersCustomer'
 ```
+
+7. Install Pimcore Members


### PR DESCRIPTION
If members is being installed earlier ( e.g. before 5), install will fail.