### PR TITLE
Fix for Exception "[] operator not supported for strings"

### DIFF
--- a/src/MembersBundle/Validator/Constraints/PimcoreUniqueEntityValidator.php
+++ b/src/MembersBundle/Validator/Constraints/PimcoreUniqueEntityValidator.php
@@ -63,7 +63,7 @@ class PimcoreUniqueEntityValidator extends ConstraintValidator
         }
 
 
-        $condition = '';
+        $condition = [];
         $values = [];
         foreach ($criteria as $criteriaName => $criteriaValue) {
             $condition[] = $criteriaName . ' = ?';


### PR DESCRIPTION
The conditions in the PimcoreUniqueEntityValidator are currently initialized as a string, but then used as an array which throws an Exception.
Fixed by initializing as an empty array.