### PR TITLE
allow access settings for all document types except mails

### DIFF
--- a/src/MembersBundle/Resources/public/js/backend/startup.js
+++ b/src/MembersBundle/Resources/public/js/backend/startup.js
@@ -130,7 +130,7 @@ pimcore.plugin.members = Class.create(pimcore.plugin.admin, {
 
         if(type === 'object' && this.settings.restriction.allowed_objects.indexOf(obj.data.general.o_className) === -1) {
             isAllowed = false;
-        } else if(type === 'page' && obj.type !== 'page') {
+        } else if(type === 'page' && obj.type === 'email') {
             isAllowed = false;
         } else if(type === 'asset' && !(obj.data.filename === 'restricted-assets' || obj.data.path.substring(0, 18) === '/restricted-assets')) {
             isAllowed = false;


### PR DESCRIPTION
reason for that is to unlock certain child items

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
