### PR TITLE
fix - the filename fallback must only contain ASCII characters

### DIFF
--- a/src/MembersBundle/Controller/RequestController.php
+++ b/src/MembersBundle/Controller/RequestController.php
@@ -77,7 +77,7 @@ class RequestController extends AbstractController
         $response->headers->set('Content-Length', $asset->getFileSize('noformatting'));
         $response->headers->set('Content-Disposition', $response->headers->makeDisposition(
             $forceDownload ? ResponseHeaderBag::DISPOSITION_ATTACHMENT : ResponseHeaderBag::DISPOSITION_INLINE,
-            basename($asset->getFileName())
+            \Pimcore\File::getValidFilename(basename($asset->getFileName()))
         ));
 
         if ($forceDownload === false) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | no

Fix InvalidArgumentException when trying to download a file named "español.pdf"