### PR TITLE
Remove Pimcore\Model\Tool\Setup from installer

### DIFF
--- a/src/MembersBundle/Tool/Install.php
+++ b/src/MembersBundle/Tool/Install.php
@@ -10,7 +10,6 @@ use Pimcore\Extension\Bundle\Installer\AbstractInstaller;
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Document;
-use Pimcore\Model\Tool\Setup;
 use Pimcore\Model\Translation;
 use Pimcore\Model\User;
 use Pimcore\Tool;
@@ -317,8 +316,10 @@ class Install extends AbstractInstaller
 
     public function injectDbData()
     {
-        $setup = new Setup();
-        $setup->insertDump($this->installSourcesPath . '/sql/install.sql');
+        $sql = file_get_contents($this->installSourcesPath . '/sql/install.sql');
+        $db = \Pimcore\Db::get();
+        $db->query($sql);
+        return true;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | 

With pimcore 5.5.3 the class Pimcore\Model\Tool\Setup is removed. This class is used in the Installer. This means that this bundle can not be properly installed in Pimcore 5.5.3. The step where database tables are created fails. This fix solves the problem by using Pimcore\Db to execute the install queries instead. Everything should still work as expected with older versions of pimcore.