### PR TITLE
fix default members password hashing algorithm

### DIFF
--- a/src/MembersBundle/Resources/install/classes/class_MembersUser_export.json
+++ b/src/MembersBundle/Resources/install/classes/class_MembersUser_export.json
@@ -142,7 +142,7 @@
                         "queryColumnType": "varchar(190)",
                         "columnType": "varchar(190)",
                         "phpdocType": "string",
-                        "algorithm": "md5",
+                        "algorithm": "password_hash",
                         "salt": "",
                         "saltlocation": "back",
                         "name": "password",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

I suggest to update the default password hashing algorithm to something more secure than md5.
