### PR TITLE
Do not wipe out UserGroups if no initial groups are set

### DIFF
--- a/src/MembersBundle/Manager/UserManager.php
+++ b/src/MembersBundle/Manager/UserManager.php
@@ -229,8 +229,9 @@ class UserManager implements UserManagerInterface
                 $userGroups[] = $objects[0];
             }
         }
-
-        $user->setGroups($userGroups);
+        if(count($userGroups)) {
+            $user->setGroups($userGroups);
+        }
 
         return $user;
     }


### PR DESCRIPTION
I found myself in the situation where i had to preset UserGroups based on some POST Parameters.
I´ve used the MembersEvents::REGISTRATION_INITIALIZE Event to hook into the registration and add
my groups to the user object.

Sadly, setupNewUser() overwrites my settings with either an empty array OR with the initial groups
set in the configuration. with this little Codechange i´m able to set the groups myself if i do need initial groups
based on different conditions.