### PR TITLE
Use Interface for Mailer so that the Mailer-Implementation gets replaceable in the Container

### DIFF
--- a/src/MembersBundle/Controller/ResettingController.php
+++ b/src/MembersBundle/Controller/ResettingController.php
@@ -7,7 +7,7 @@ use MembersBundle\Event\FilterUserResponseEvent;
 use MembersBundle\Event\FormEvent;
 use MembersBundle\Event\GetResponseNullableUserEvent;
 use MembersBundle\Event\GetResponseUserEvent;
-use MembersBundle\Mailer\Mailer;
+use MembersBundle\Mailer\MailerInterface;
 use MembersBundle\Manager\UserManager;
 use MembersBundle\MembersEvents;
 use MembersBundle\Tool\TokenGenerator;
@@ -28,6 +28,7 @@ class ResettingController extends AbstractController
      */
     public function requestAction(Request $request)
     {
+
         /** @var \MembersBundle\Form\Factory\FactoryInterface $formFactory */
         $formFactory = $this->get('members.resetting_request.form.factory');
 
@@ -46,6 +47,7 @@ class ResettingController extends AbstractController
      */
     public function sendEmailAction(Request $request)
     {
+
         $username = $request->request->get('username');
 
         /** @var UserInterface $user */
@@ -59,13 +61,14 @@ class ResettingController extends AbstractController
         $dispatcher->dispatch(MembersEvents::RESETTING_SEND_EMAIL_INITIALIZE, $event);
 
         if (null !== $event->getResponse()) {
-            return $event->getResponse();
+          return $event->getResponse();
         }
+
 
         $ttl = $this->getParameter('members.resetting.retry_ttl');
         if ($user !== null && !$user->isPasswordRequestNonExpired($ttl)) {
-            $event = new GetResponseUserEvent($user, $request);
-            $dispatcher->dispatch(MembersEvents::RESETTING_RESET_REQUEST, $event);
+          $event = new GetResponseUserEvent($user, $request);
+          $dispatcher->dispatch(MembersEvents::RESETTING_RESET_REQUEST, $event);
 
             if (null !== $event->getResponse()) {
                 return $event->getResponse();
@@ -85,7 +88,7 @@ class ResettingController extends AbstractController
                 return $event->getResponse();
             }
 
-            $this->get(Mailer::class)->sendResettingEmailMessage($user);
+            $this->get(MailerInterface::class)->sendResettingEmailMessage($user);
             $user->setPasswordRequestedAt(new \Carbon\Carbon());
             $this->get(UserManager::class)->updateUser($user);
 
@@ -176,7 +179,7 @@ class ResettingController extends AbstractController
 
         return $this->renderTemplate('@Members/Resetting/reset.html.twig', [
             'token' => $token,
-            'form'  => $form->createView(),
+            'form' => $form->createView(),
         ]);
     }
 }

--- a/src/MembersBundle/EventListener/PostConfirmationListener.php
+++ b/src/MembersBundle/EventListener/PostConfirmationListener.php
@@ -4,7 +4,7 @@ namespace MembersBundle\EventListener;
 
 use MembersBundle\Adapter\User\UserInterface;
 use MembersBundle\Event\FormEvent;
-use MembersBundle\Mailer\Mailer;
+use MembersBundle\Mailer\MailerInterface;
 use MembersBundle\Manager\UserManagerInterface;
 use MembersBundle\MembersEvents;
 use MembersBundle\Tool\TokenGenerator;
@@ -21,7 +21,7 @@ class PostConfirmationListener implements EventSubscriberInterface
     protected $userManager;
 
     /**
-     * @var Mailer
+     * @var MailerInterface
      */
     protected $mailer;
 
@@ -49,7 +49,7 @@ class PostConfirmationListener implements EventSubscriberInterface
      * EmailConfirmationListener constructor.
      *
      * @param UserManagerInterface  $userManager
-     * @param Mailer                $pimcoreMailer
+     * @param MailerInterface                $mailer
      * @param UrlGeneratorInterface $router
      * @param SessionInterface      $session
      * @param TokenGenerator        $tokenGenerator
@@ -57,14 +57,14 @@ class PostConfirmationListener implements EventSubscriberInterface
      */
     public function __construct(
         UserManagerInterface $userManager,
-        Mailer $pimcoreMailer,
+        MailerInterface $mailer,
         UrlGeneratorInterface $router,
         SessionInterface $session,
         TokenGenerator $tokenGenerator,
         string $postEventType
     ) {
         $this->userManager = $userManager;
-        $this->mailer = $pimcoreMailer;
+        $this->mailer = $mailer;
         $this->tokenGenerator = $tokenGenerator;
         $this->router = $router;
         $this->session = $session;

--- a/src/MembersBundle/EventListener/UserChangeListener.php
+++ b/src/MembersBundle/EventListener/UserChangeListener.php
@@ -3,7 +3,7 @@
 namespace MembersBundle\EventListener;
 
 use MembersBundle\Adapter\User\UserInterface;
-use MembersBundle\Mailer\Mailer;
+use MembersBundle\Mailer\MailerInterface;
 use MembersBundle\Manager\UserManagerInterface;
 use Pimcore\Event\DataObjectEvents;
 use Pimcore\Event\Model\DataObjectEvent;
@@ -17,7 +17,7 @@ class UserChangeListener implements EventSubscriberInterface
     protected $userManager;
 
     /**
-     * @var Mailer
+     * @var MailerInterface
      */
     protected $mailer;
 
@@ -30,12 +30,12 @@ class UserChangeListener implements EventSubscriberInterface
      * UserChangeListener constructor.
      *
      * @param UserManagerInterface $userManager
-     * @param Mailer               $pimcoreMailer
+     * @param MailerInterface               $pimcoreMailer
      * @param string               $postEventType
      */
     public function __construct(
         UserManagerInterface $userManager,
-        Mailer $pimcoreMailer,
+        MailerInterface $pimcoreMailer,
         string $postEventType
     ) {
         $this->userManager = $userManager;

--- a/src/MembersBundle/Mailer/Mailer.php
+++ b/src/MembersBundle/Mailer/Mailer.php
@@ -40,7 +40,7 @@ class Mailer implements MailerInterface
         $url = $this->router->generate('members_user_registration_confirm', ['token' => $user->getConfirmationToken()], UrlGeneratorInterface::ABSOLUTE_URL);
 
         $mailParams = [
-            'user'            => $user,
+            'user' => $user,
             'confirmationUrl' => $url
         ];
 
@@ -60,7 +60,7 @@ class Mailer implements MailerInterface
         $url = $this->generateUrl('members_user_security_login', $user);
 
         $mailParams = [
-            'user'      => $user,
+            'user' => $user,
             'loginpage' => $url
         ];
 
@@ -76,7 +76,7 @@ class Mailer implements MailerInterface
         $url = $this->generateUrl('members_user_resetting_reset', $user, ['token' => $user->getConfirmationToken()]);
 
         $mailParams = [
-            'user'            => $user,
+            'user' => $user,
             'confirmationUrl' => $url
         ];
 
@@ -96,7 +96,7 @@ class Mailer implements MailerInterface
         $url = $this->generateUrl('pimcore_admin_login_deeplink', $user, [], false);
 
         $mailParams = [
-            'user'     => $user,
+            'user' => $user,
             'deeplink' => $url . '?' . 'object_' . $user->getId() . '_object' //thanks pimcore.
         ];
 

--- a/src/MembersBundle/Mailer/MailerInterface.php
+++ b/src/MembersBundle/Mailer/MailerInterface.php
@@ -19,4 +19,18 @@ interface MailerInterface
      * @param UserInterface $user
      */
     public function sendResettingEmailMessage(UserInterface $user);
+
+    /**
+     * Send email to admin to confirm the registration
+     *
+     * @param UserInterface $user
+     */
+    public function sendAdminNotificationEmailMessage(UserInterface $user);
+
+       /**
+        * Notify user after an admin confirmed the registration
+        *
+     * @param UserInterface $user
+     */
+    public function sendConfirmedEmailMessage(UserInterface $user);
 }

--- a/src/MembersBundle/Manager/UserManager.php
+++ b/src/MembersBundle/Manager/UserManager.php
@@ -229,8 +229,9 @@ class UserManager implements UserManagerInterface
                 $userGroups[] = $objects[0];
             }
         }
-
-        $user->setGroups($userGroups);
+        if(count($userGroups)) {
+            $user->setGroups($userGroups);
+        }
 
         return $user;
     }

--- a/src/MembersBundle/Resources/config/services/mail.yml
+++ b/src/MembersBundle/Resources/config/services/mail.yml
@@ -6,3 +6,4 @@ services:
         public: true
 
     MembersBundle\Mailer\Mailer: ~
+    MembersBundle\Mailer\MailerInterface: '@MembersBundle\Mailer\Mailer'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #107 

With this change we´re able to replace the Mailer-Implementation for transactional mails with our own implementation.

Just bind your own service the the interface 
```yaml
services:

    _defaults:
        autowire: true
        autoconfigure: true
        public: true

    MembersBundle\Mailer\MailerInterface: '@AppBundle\Mailer\Mailer'
```
>our service has to implement the MailerInterface

```php
<?php
use MembersBundle\Mailer\MailerInterface;

class Mailer implements MailerInterface
{
  // add your implementation
}
?>
```