### PR TITLE
fix: inject the token storage interface instead of the class

### DIFF
--- a/src/MembersBundle/Document/Builder/BrickBuilder.php
+++ b/src/MembersBundle/Document/Builder/BrickBuilder.php
@@ -8,7 +8,7 @@ use Pimcore\Placeholder;
 use Pimcore\Templating\Renderer\IncludeRenderer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Security;
 
@@ -25,7 +25,7 @@ class BrickBuilder
     protected $includeRenderer;
 
     /**
-     * @var TokenStorage
+     * @var TokenStorageInterface
      */
     protected $tokenStorage;
 
@@ -82,12 +82,12 @@ class BrickBuilder
     /**
      * AreaBuilder constructor.
      *
-     * @param TokenStorage          $tokenStorage
+     * @param TokenStorageInterface $tokenStorage
      * @param IncludeRenderer       $includeRenderer
      * @param UrlGeneratorInterface $urlGenerator
      */
     public function __construct(
-        TokenStorage $tokenStorage,
+        TokenStorageInterface $tokenStorage,
         IncludeRenderer $includeRenderer,
         UrlGeneratorInterface $urlGenerator
     ) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

After updating to Pimcore 6.3.3 (and more importantly Symfony 4.4) I got following error:
![di_error](https://user-images.githubusercontent.com/17384333/69558660-e2126480-0fa8-11ea-8a55-add40f61be28.png)

When moving from Symfony 4.3 to 4.4 we have to use the `TokenStorageInterface` instead of the class directly, as you can see here: https://github.com/symfony/symfony/commit/20df3a125cfb56794ada342ddf96023b91854a9c#diff-c437482da579aadf3e37c903af62fccdR24-R34