### PR TITLE
fix: remove the handle request call, since Symfony handles it by defa…

### DIFF
--- a/src/MembersBundle/Controller/AuthController.php
+++ b/src/MembersBundle/Controller/AuthController.php
@@ -45,8 +45,6 @@ class AuthController extends AbstractController
 
         $form = $this->formFactory->createUnnamedFormWithOptions(['last_username' => $lastUsername]);
 
-        $form->handleRequest($request);
-
         // get the error if any (works with forward and redirect -- see below)
         if ($request->attributes->has($authErrorKey)) {
             $error = $request->attributes->get($authErrorKey);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

This PR removes the `handleRequest` call for the login form, since it is not needed. Symfony does that already by default. If not removed, Symfony throws an error: `The CSRF token is invalid. Please try to resubmit the form.`.
