### PR TITLE
only set Initial Groups if present

### DIFF
--- a/src/MembersBundle/Manager/UserManager.php
+++ b/src/MembersBundle/Manager/UserManager.php
@@ -262,7 +262,9 @@ class UserManager implements UserManagerInterface
             }
         }
 
-        $user->setGroups($userGroups);
+        if (count($userGroups)) {
+            $user->setGroups($userGroups);
+        }
 
         return $user;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

only set the initial groups if initial groups are present in the config. this prevents the groups field from being emptied when setting the groups-field via for example a form.
