### PR TITLE
Invalid link - password reset email

### DIFF
--- a/src/MembersBundle/Resources/install/emails-Members.json
+++ b/src/MembersBundle/Resources/install/emails-Members.json
@@ -92,7 +92,7 @@
                 {
                     "key": "email_content",
                     "type": "wysiwyg",
-                    "value": "<p>Hallo %DataObject(user,{\"method\" : \"getUsername\"});!</p><p>Besuchen Sie bitte folgende Seite, um Ihr Passwort zurückzusetzen: %Text(confirmationUrl);!</p><p>Mit besten Grüßen, das Team.</p>"
+                    "value": "<p>Hallo %DataObject(user,{\"method\" : \"getUsername\"});!</p><p>Besuchen Sie bitte folgende Seite, um Ihr Passwort zurückzusetzen: %Text(confirmationUrl); !</p><p>Mit besten Grüßen, das Team.</p>"
                 }
             ],
             "en": [


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

It seems, some email clients add the "!" after the password reset link into the link! In my case this results in an invalid password reset link.
