### PR TITLE
Issue with setting a default group

### DIFF
--- a/src/MembersBundle/Manager/UserManager.php
+++ b/src/MembersBundle/Manager/UserManager.php
@@ -213,8 +213,8 @@ class UserManager implements UserManagerInterface
         //It's a new user!
         if (empty($user->getKey())) {
             $new = true;
-            $user = $this->setupNewUser($user, null);
         }
+        $user = $this->setupNewUser($user, null);
 
         // update user properties.
         if (!empty($properties)) {


### PR DESCRIPTION
While using Sso to create a user the conditional statement on line 214 may not be fired and will not allow the default groups to be set. Moving the updateUser() method call outside of this conditional seems to have resolved the issue.

| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
