### PR TITLE
fix: protect documents starting with admin

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,6 +9,7 @@ Just click the "update" button or execute the migration command to finish the bu
 #### Update from Version 3.1.3 to Version 3.1.4
 - **[ENHANCEMENT]**: Improving and adding additional Events for Restriction Changes on Entities ([#148](https://github.com/dachcom-digital/pimcore-members/issues/148))
 - **[ENHANCEMENT]**: Update Twig navigation to allow parameters ([@kjkooistra-youwe](https://github.com/dachcom-digital/pimcore-members/pull/147))
+- **[ENHANCEMENT]**: Protect documents starting with admin ([@youwe-petervanderwal](https://github.com/dachcom-digital/pimcore-members/pull/145))
 
 #### Update from Version 3.1.2 to Version 3.1.3
 - **[ENHANCEMENT]**: Pimcore 6.6.5 ready

--- a/src/MembersBundle/Resources/config/pimcore/config.yml
+++ b/src/MembersBundle/Resources/config/pimcore/config.yml
@@ -14,7 +14,7 @@ security:
             id: MembersBundle\Security\UserProvider
     firewalls:
         members_fe:
-            pattern: ^/(?!(admin)).*$
+            pattern: ^/(?!(admin)($|/)).*$
             logout_on_user_change: true
             provider: members
             form_login:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.5
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -

Problem: Documents with an url like '/administration' weren't redirected to the login page
Caused by: All uri's starting with '/admin' were excluded from the firewall
Resolved by: Only ignoring '/admin' itself and '/admin/.*'