### PR TITLE
fix: falsely checking routes without contentDocument

### DIFF
--- a/src/MembersBundle/EventListener/ForbiddenRouteListener.php
+++ b/src/MembersBundle/EventListener/ForbiddenRouteListener.php
@@ -80,7 +80,8 @@ class ForbiddenRouteListener implements EventSubscriberInterface
 
         $restriction = false;
 
-        if (strpos($event->getRequest()->attributes->get('_route'), 'document_') !== false) {
+        // TODO: Use `str_starts_with` function once PHP requirement is >= 8.0
+        if (substr($event->getRequest()->attributes->get('_route'), 0, 9) === 'document_') {
             $document = $event->getRequest()->get(DynamicRouter::CONTENT_KEY, null);
             $restriction = $this->restrictionManager->getElementRestrictionStatus($document);
         } elseif ($event->getRequest()->attributes->get('pimcore_request_source') === 'staticroute') {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

[This line](https://github.com/dachcom-digital/pimcore-members/blob/master/src/MembersBundle/EventListener/ForbiddenRouteListener.php#L83) is checking if route names contain `document_` anywhere in them. In one project I had the route `app_order_document_preview `, which of course didn't contain a `contentDocument` key in the request. Because of that the restriction status check failed with the error:

```log
Argument 1 passed to MembersBundle\Manager\RestrictionManager::getElementRestrictionStatus() must be an instance of Pimcore\Model\AbstractModel, null given
```

With this PR the check explicitly checks if the string begins with `document_`.