### PR TITLE
improve restriction event handling, resolves #148

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,9 @@
 After every update you should check the pimcore extension manager. 
 Just click the "update" button or execute the migration command to finish the bundle update.
 
+#### Update from Version 3.1.3 to Version 3.1.4
+- **[ENHANCEMENT]**: Improving and adding additional Events for Restriction Changes on Entities ([#148](https://github.com/dachcom-digital/pimcore-members/issues/148))
+
 #### Update from Version 3.1.2 to Version 3.1.3
 - **[ENHANCEMENT]**: Pimcore 6.6.5 ready
 - **[ENHANCEMENT]**: only set Initial Groups if present ([#135](https://github.com/dachcom-digital/pimcore-members/pull/135))

--- a/docs/40_Events.md
+++ b/docs/40_Events.md
@@ -11,6 +11,39 @@
 
 ***
 
+### members.entity.restriction.create
+
+| Type | Reference |
+|:--- |:--- |
+| **const** | `\MembersEvent:ENTITY_CREATE_RESTRICTION` |
+| **name** | `members.entity.restriction.create` |
+| **class** | `\MembersBundle\Event\RestrictionEvent` |
+| **description** | The ENTITY_CREATE_RESTRICTION event occurs after a restriction has been created |
+
+***
+
+### members.entity.restriction.update
+
+| Type | Reference |
+|:--- |:--- |
+| **const** | `\MembersEvent:ENTITY_UPDATE_RESTRICTION` |
+| **name** | `members.entity.restriction.update` |
+| **class** | `\MembersBundle\Event\RestrictionEvent` |
+| **description** | ENTITY_UPDATE_RESTRICTION event occurs after a restriction has been updated |
+
+***
+
+### members.entity.restriction.delete
+
+| Type | Reference |
+|:--- |:--- |
+| **const** | `\MembersEvent:ENTITY_DELETE_RESTRICTION` |
+| **name** | `members.entity.restriction.delete` |
+| **class** | `\MembersBundle\Event\RestrictionEvent` |
+| **description** | The ENTITY_DELETE_RESTRICTION event occurs after a restriction has been deleted |
+
+***
+
 ### members.change_password.edit.initialize
 
 | Type | Reference |

--- a/src/MembersBundle/Controller/Admin/RestrictionController.php
+++ b/src/MembersBundle/Controller/Admin/RestrictionController.php
@@ -168,38 +168,8 @@ class RestrictionController extends AdminController
             'success'    => true,
             'isActive'   => !empty($groups),
             'docId'      => (int) $settings->docId,
-            'userGroups' => !empty($groups) ? $restriction->getRelatedGroups() : []
+            'userGroups' => $restriction instanceof Restriction ? $restriction->getRelatedGroups() : []
         ]);
-    }
-
-    /**
-     * @param Request $request
-     *
-     * @return JsonResponse
-     *
-     * @throws \Doctrine\DBAL\DBALException
-     * @throws \Doctrine\DBAL\Exception\InvalidArgumentException
-     */
-    public function deleteDocumentRestrictionConfigAction(Request $request)
-    {
-        $data = json_decode($request->query->get('data'));
-
-        $docId = (int) $data->docId;
-        $cType = $data->cType; //object|page|asset
-
-        $restriction = false;
-
-        try {
-            $restriction = Restriction::getByTargetId($docId, $cType);
-        } catch (\Exception $e) {
-        }
-
-        //restriction has been disabled! remove everything!
-        if ($restriction !== false) {
-            $restriction->getDao()->delete();
-        }
-
-        return $this->json(['success' => true]);
     }
 
     /**

--- a/src/MembersBundle/Controller/Admin/RestrictionController.php
+++ b/src/MembersBundle/Controller/Admin/RestrictionController.php
@@ -8,6 +8,7 @@ use MembersBundle\Restriction\Restriction;
 use MembersBundle\Service\RestrictionService;
 use Pimcore\Bundle\AdminBundle\Controller\AdminController;
 use MembersBundle\Configuration\Configuration;
+use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -136,22 +137,26 @@ class RestrictionController extends AdminController
      */
     public function setDocumentRestrictionConfigAction(Request $request)
     {
-        $data = json_decode($request->query->get('data'));
+        $data = json_decode($request->query->get('data'), true);
 
-        $docId = (int) $data->docId;
-        $settings = $data->settings;
-        $cType = $data->cType; //object|page|asset
+        $docId = (int) $data['docId'];
+        $settings = $data['settings'] ?? null;
+        $cType = $data['cType'] ?? null; //object|page|asset
 
         $pimcoreType = 'document';
-        if ($cType == 'object') {
+        if ($cType === 'object') {
             $pimcoreType = 'object';
-        } elseif ($cType == 'asset') {
+        } elseif ($cType === 'asset') {
             $pimcoreType = 'asset';
         }
 
         $obj = Service::getElementById($pimcoreType, $docId);
 
-        $inheritableState = $settings->membersDocumentInheritable;
+        if (!$obj instanceof ElementInterface) {
+            return $this->json(['success' => false]);
+        }
+
+        $inheritableState = $settings['membersDocumentInheritable'];
 
         if ($inheritableState === 'on') {
             $inheritable = true;
@@ -161,13 +166,13 @@ class RestrictionController extends AdminController
             $inheritable = false;
         }
 
-        $groups = array_filter(explode(',', $settings->membersDocumentUserGroups));
+        $groups = array_filter(explode(',', $settings['membersDocumentUserGroups']));
         $restriction = $this->restrictionService->createRestriction($obj, $cType, $inheritable, false, $groups);
 
         return $this->json([
             'success'    => true,
             'isActive'   => !empty($groups),
-            'docId'      => (int) $settings->docId,
+            'docId'      => (int) $settings['docId'],
             'userGroups' => $restriction instanceof Restriction ? $restriction->getRelatedGroups() : []
         ]);
     }

--- a/src/MembersBundle/Event/RestrictionEvent.php
+++ b/src/MembersBundle/Event/RestrictionEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace MembersBundle\Event;
+
+use MembersBundle\Restriction\Restriction;
+use Pimcore\Model\Element\ElementInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+class RestrictionEvent extends Event
+{
+    /**
+     * @var ElementInterface
+     */
+    protected $element;
+
+    /**
+     * @var Restriction|null
+     */
+    protected $restriction;
+
+    /**
+     * @param ElementInterface $element
+     * @param Restriction|null $restriction
+     */
+    public function __construct(ElementInterface $element, ?Restriction $restriction)
+    {
+        $this->element = $element;
+        $this->restriction = $restriction;
+    }
+
+    /**
+     * @return ElementInterface
+     */
+    public function getElement()
+    {
+        return $this->element;
+    }
+
+    /**
+     * @return Restriction|null
+     */
+    public function getRestriction()
+    {
+        return $this->restriction;
+    }
+}

--- a/src/MembersBundle/EventListener/RestrictionStoreListener.php
+++ b/src/MembersBundle/EventListener/RestrictionStoreListener.php
@@ -9,29 +9,20 @@ use Pimcore\Event\Model\DocumentEvent;
 use Pimcore\Event\DataObjectEvents;
 use Pimcore\Event\Model\DataObjectEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use MembersBundle\Service\RestrictionService;
 
 class RestrictionStoreListener implements EventSubscriberInterface
 {
-    /**
-     * @var RequestStack
-     */
-    protected $requestStack;
-
     /**
      * @var RestrictionService
      */
     protected $serviceRestriction;
 
     /**
-     * @param RequestStack       $requestStack
      * @param RestrictionService $serviceRestriction
      */
-    public function __construct(RequestStack $requestStack, RestrictionService $serviceRestriction)
+    public function __construct(RestrictionService $serviceRestriction)
     {
-        $this->requestStack = $requestStack;
         $this->serviceRestriction = $serviceRestriction;
     }
 
@@ -108,15 +99,9 @@ class RestrictionStoreListener implements EventSubscriberInterface
      */
     public function handleObjectUpdate(DataObjectEvent $e)
     {
-        if (!$this->requestStack->getMasterRequest() instanceof Request) {
-            return;
-        }
-
-        $params = $this->requestStack->getMasterRequest()->get('values');
-
         //only trigger update if object gets moved.
-        //default restriction object update gets handled by restrictionController.
-        if ($params === null) {
+        //default restriction page update gets handled by restrictionController or API.
+        if ($e->hasArgument('oldPath') === false) {
             return;
         }
 
@@ -128,15 +113,9 @@ class RestrictionStoreListener implements EventSubscriberInterface
      */
     public function handleDocumentUpdate(DocumentEvent $e)
     {
-        if (!$this->requestStack->getMasterRequest() instanceof Request) {
-            return;
-        }
-
-        $params = $this->requestStack->getMasterRequest()->get('parentId');
-
         //only trigger update if page gets moved.
-        //default restriction page update gets handled by restrictionController.
-        if ($params === null) {
+        //default restriction page update gets handled by restrictionController or API.
+        if ($e->hasArgument('oldPath') === false) {
             return;
         }
 
@@ -148,15 +127,9 @@ class RestrictionStoreListener implements EventSubscriberInterface
      */
     public function handleAssetUpdate(AssetEvent $e)
     {
-        if (!$this->requestStack->getMasterRequest() instanceof Request) {
-            return;
-        }
-
-        $params = $this->requestStack->getMasterRequest()->get('parentId');
-
         //only trigger update if asset gets moved.
-        //default restriction asset update gets handled by restrictionController.
-        if ($params === null) {
+        //default restriction page update gets handled by restrictionController or API.
+        if ($e->hasArgument('oldPath') === false) {
             return;
         }
 

--- a/src/MembersBundle/MembersEvents.php
+++ b/src/MembersBundle/MembersEvents.php
@@ -12,6 +12,27 @@ final class MembersEvents
     const RESTRICTION_CHECK_STATICROUTE = 'members.restriction.staticroute';
 
     /**
+     * The ENTITY_CREATE_RESTRICTION event occurs after a restriction has been created
+     *
+     * @Event("MembersBundle\Event\RestrictionEvent")
+     */
+    const ENTITY_CREATE_RESTRICTION = 'members.entity.restriction.create';
+
+    /**
+     * The ENTITY_UPDATE_RESTRICTION event occurs after a restriction has been updated
+     *
+     * @Event("MembersBundle\Event\RestrictionEvent")
+     */
+    const ENTITY_UPDATE_RESTRICTION = 'members.entity.restriction.update';
+
+    /**
+     * The ENTITY_DELETE_RESTRICTION event occurs after a restriction has been deleted
+     *
+     * @Event("MembersBundle\Event\RestrictionEvent")
+     */
+    const ENTITY_DELETE_RESTRICTION = 'members.entity.restriction.delete';
+
+    /**
      * The CHANGE_PASSWORD_INITIALIZE event occurs when the change password process is initialized.
      *
      * This event allows you to modify the default values of the user before binding the form.

--- a/src/MembersBundle/Resources/config/pimcore/routing.yml
+++ b/src/MembersBundle/Resources/config/pimcore/routing.yml
@@ -13,9 +13,6 @@ members.controller.admin.get_groups:
 members.controller.admin.get_next_parent_restriction:
     path: /admin/members/restriction/get-next-parent-restriction
     defaults: { _controller: MembersBundle\Controller\Admin\RestrictionController::getNextParentRestrictionAction }
-members.controller.admin.delete_document_restriction_config:
-    path: /admin/members/restriction/delete-document-restriction-config
-    defaults: { _controller: MembersBundle\Controller\Admin\RestrictionController::deleteDocumentRestrictionConfigAction }
 members.asset_request:
     path: /members/request-data/{hash}
     defaults: { _controller: MembersBundle\Controller\RequestController::serveAction }

--- a/src/MembersBundle/Resources/public/js/backend/document/restriction.js
+++ b/src/MembersBundle/Resources/public/js/backend/document/restriction.js
@@ -1,23 +1,12 @@
 pimcore.registerNS('pimcore.plugin.members.document.restriction');
 pimcore.plugin.members.document.restriction = Class.create({
-    /**
-     *
-     */
+
     layout : null,
 
-    /**
-     *
-     */
     element : null,
 
-    /**
-     *
-     */
     data : null,
 
-    /**
-     *
-     */
     userGroupsStore : null,
 
     /**
@@ -25,9 +14,6 @@ pimcore.plugin.members.document.restriction = Class.create({
      */
     cType : null,
 
-    /**
-     * constructor
-     */
     initialize: function(doc) {
         this.element = doc;
     },
@@ -262,30 +248,11 @@ pimcore.plugin.members.document.restriction = Class.create({
         };
 
         Ext.Ajax.request({
-
             url: '/admin/members/restriction/set-document-restriction-config',
             params: {
                 data : Ext.encode(values)
             }
-
         });
 
-    },
-
-    delete : function() {
-
-        var _self = this,
-            values = {
-                docId: _self.element.id,
-                cType : _self.cType
-            };
-
-        Ext.Ajax.request({
-
-            url: '/admin/members/restriction/delete-document-restriction-config',
-            params: {
-                data : Ext.encode(values)
-            }
-        });
     }
 });

--- a/src/MembersBundle/Resources/public/js/backend/startup.js
+++ b/src/MembersBundle/Resources/public/js/backend/startup.js
@@ -4,7 +4,7 @@ pimcore.registerNS('pimcore.plugin.members');
 pimcore.plugin.members = Class.create(pimcore.plugin.admin, {
 
     settings: {},
-    ready : false,
+    ready: false,
     dataQueue: [],
 
     getClassName: function () {
@@ -30,25 +30,21 @@ pimcore.plugin.members = Class.create(pimcore.plugin.admin, {
                 this.processQueue();
 
             }.bind(this)
-
         });
-
-        var user = pimcore.globalmanager.get('user');
 
     },
 
     openSettings: function () {
         try {
             pimcore.globalmanager.get('members_settings').activate();
-        }
-        catch (e) {
+        } catch (e) {
             pimcore.globalmanager.add('members_settings', new pimcore.plugin.members.settings());
         }
     },
 
     postOpenDocument: function (doc) {
 
-        if( this.ready ) {
+        if (this.ready) {
             this.processElement(doc, 'page');
         } else {
             this.addElementToQueue(doc, 'page');
@@ -57,7 +53,7 @@ pimcore.plugin.members = Class.create(pimcore.plugin.admin, {
 
     postOpenObject: function (obj) {
 
-        if( this.ready ) {
+        if (this.ready) {
             this.processElement(obj, 'object');
         } else {
             this.addElementToQueue(obj, 'object');
@@ -66,7 +62,7 @@ pimcore.plugin.members = Class.create(pimcore.plugin.admin, {
 
     postOpenAsset: function (asset) {
 
-        if( this.ready ) {
+        if (this.ready) {
             this.processElement(asset, 'asset');
         } else {
             this.addElementToQueue(asset, 'asset');
@@ -75,14 +71,14 @@ pimcore.plugin.members = Class.create(pimcore.plugin.admin, {
 
     postSaveDocument: function (doc, type, task, only) {
 
-        if( doc.members ) {
+        if (doc.members) {
             doc.members.restrictionTab.save();
         }
     },
 
     postSaveObject: function (obj, task, only) {
 
-        if( obj.members ) {
+        if (obj.members) {
             obj.members.restrictionTab.save();
         }
     },
@@ -93,21 +89,21 @@ pimcore.plugin.members = Class.create(pimcore.plugin.admin, {
 
         if (pimcore.globalmanager.exists('asset_' + assetId) !== false) {
             asset = pimcore.globalmanager.get('asset_' + assetId);
-            if( asset.members ) {
+            if (asset.members) {
                 asset.members.restrictionTab.save();
             }
         }
     },
 
-    addElementToQueue: function(obj, type) {
-        this.dataQueue.push({'obj' : obj, 'type' : type});
+    addElementToQueue: function (obj, type) {
+        this.dataQueue.push({'obj': obj, 'type': type});
     },
 
-    processQueue: function() {
+    processQueue: function () {
 
-        if(this.dataQueue.length > 0) {
+        if (this.dataQueue.length > 0) {
 
-            Ext.each(this.dataQueue, function(data) {
+            Ext.each(this.dataQueue, function (data) {
 
                 var obj = data.obj,
                     type = data.type;
@@ -120,23 +116,23 @@ pimcore.plugin.members = Class.create(pimcore.plugin.admin, {
         }
     },
 
-    processElement: function(obj, type) {
-
-        if(this.settings.restriction.enabled === false) {
-            return false;
-        }
+    processElement: function (obj, type) {
 
         var isAllowed = true;
 
-        if(type === 'object' && this.settings.restriction.allowed_objects.indexOf(obj.data.general.o_className) === -1) {
+        if (this.settings.restriction.enabled === false) {
+            return false;
+        }
+
+        if (type === 'object' && this.settings.restriction.allowed_objects.indexOf(obj.data.general.o_className) === -1) {
             isAllowed = false;
-        } else if(type === 'page' && ['page', 'link'].indexOf(obj.type ) === -1) {
+        } else if (type === 'page' && ['page', 'link'].indexOf(obj.type) === -1) {
             isAllowed = false;
-        } else if(type === 'asset' && !(obj.data.filename === 'restricted-assets' || obj.data.path.substring(0, 18) === '/restricted-assets')) {
+        } else if (type === 'asset' && !(obj.data.filename === 'restricted-assets' || obj.data.path.substring(0, 18) === '/restricted-assets')) {
             isAllowed = false;
         }
 
-        if(isAllowed) {
+        if (isAllowed) {
             obj.members = {};
             var restrictionTab = new pimcore.plugin.members.document.restriction(obj);
             restrictionTab.setup(type);

--- a/tests/functional/Restriction/AssetRestrictionCest.php
+++ b/tests/functional/Restriction/AssetRestrictionCest.php
@@ -97,4 +97,71 @@ class AssetRestrictionCest
 
         $I->seeDownloadLinkZip('package.zip', $link);
     }
+
+    /**
+     * @param FunctionalTester $I
+     *
+     * @throws ModuleException
+     * @throws \Exception
+     */
+    public function testAssetInheritanceRestriction(FunctionalTester $I)
+    {
+        $group1 = $I->haveAFrontendUserGroup('group-1');
+        $restrictedFolder = $I->haveAProtectedAssetFolder();
+
+        $assetFolder = $I->haveASubPimcoreAssetFolder($restrictedFolder, 'sub-folder');
+        $subAsset = $I->haveASubPimcoreAsset($assetFolder, 'sub-asset-1');
+
+        $I->addRestrictionToAsset($assetFolder, [$group1->getId()], true, false);
+
+        $I->seeInheritedRestrictionOnEntity($subAsset);
+        $I->seeRestrictionWithGroupsOnEntity($subAsset, [$group1]);
+
+        $I->changeRestrictionToAsset($assetFolder, [$group1->getId()], false, false);
+
+        $I->seeRestrictionOnEntity($assetFolder);
+        $I->seeNoRestrictionOnEntity($subAsset);
+    }
+
+    /**
+     * @param FunctionalTester $I
+     *
+     * @throws ModuleException
+     * @throws \Exception
+     */
+    public function testNewAddedAssetInheritanceRestriction(FunctionalTester $I)
+    {
+        $group1 = $I->haveAFrontendUserGroup('group-1');
+        $restrictedFolder = $I->haveAProtectedAssetFolder();
+
+        $assetFolder = $I->haveASubPimcoreAssetFolder($restrictedFolder, 'sub-folder');
+
+        $I->addRestrictionToAsset($assetFolder, [$group1->getId()], true, false);
+
+        $subAsset = $I->haveASubPimcoreAsset($assetFolder, 'sub-asset-1');
+        $I->seeInheritedRestrictionOnEntity($subAsset);
+    }
+
+    /**
+     * @param FunctionalTester $I
+     *
+     * @throws ModuleException
+     * @throws \Exception
+     */
+    public function testMovedAssetInheritanceRestriction(FunctionalTester $I)
+    {
+        $group1 = $I->haveAFrontendUserGroup('group-1');
+        $restrictedFolder = $I->haveAProtectedAssetFolder();
+
+        $assetFolder1 = $I->haveASubPimcoreAssetFolder($restrictedFolder, 'sub-folder-1');
+        $assetFolder2 = $I->haveASubPimcoreAssetFolder($restrictedFolder, 'sub-folder-2');
+
+        $subAsset1 = $I->haveASubPimcoreAsset($assetFolder1, 'sub-asset-1');
+
+        $I->addRestrictionToAsset($assetFolder1, [$group1->getId()], true, false);
+
+        $I->seeInheritedRestrictionOnEntity($subAsset1);
+        $I->moveAsset($subAsset1, $assetFolder2);
+        $I->seeNoRestrictionOnEntity($subAsset1);
+    }
 }

--- a/tests/functional/Restriction/DocumentRestrictionCest.php
+++ b/tests/functional/Restriction/DocumentRestrictionCest.php
@@ -60,4 +60,73 @@ class DocumentRestrictionCest
         $I->see('Test Page for Members', 'title');
     }
 
+    /**
+     * @param FunctionalTester $I
+     *
+     * @throws ModuleException
+     * @throws \Exception
+     */
+    public function testDocumentInheritanceRestriction(FunctionalTester $I)
+    {
+        $group1 = $I->haveAFrontendUserGroup('group-1');
+
+        $document = $I->haveAPageDocument('document-1');
+        $subDocument = $I->haveASubPageDocument($document, 'sub-document-1');
+        $subSubDocument = $I->haveASubPageDocument($subDocument, 'sub-sub-document-1');
+
+        $I->addRestrictionToDocument($document, [$group1->getId()], true, false);
+
+        $I->seeInheritedRestrictionOnEntity($subDocument);
+        $I->seeInheritedRestrictionOnEntity($subSubDocument);
+        $I->seeRestrictionWithGroupsOnEntity($subDocument, [$group1]);
+        $I->seeRestrictionWithGroupsOnEntity($subSubDocument, [$group1]);
+
+        $I->changeRestrictionToDocument($document, [$group1->getId()], false, false);
+
+        $I->seeRestrictionOnEntity($document);
+        $I->seeNoRestrictionOnEntity($subDocument);
+        $I->seeNoRestrictionOnEntity($subSubDocument);
+    }
+
+    /**
+     * @param FunctionalTester $I
+     *
+     * @throws ModuleException
+     * @throws \Exception
+     */
+    public function testNewAddedDocumentInheritanceRestriction(FunctionalTester $I)
+    {
+        $group1 = $I->haveAFrontendUserGroup('group-1');
+
+        $document = $I->haveAPageDocument('document-1');
+        $I->addRestrictionToDocument($document, [$group1->getId()], true, false);
+
+        $subDocument = $I->haveASubPageDocument($document, 'sub-document-1');
+        $I->seeInheritedRestrictionOnEntity($subDocument);
+    }
+
+    /**
+     * @param FunctionalTester $I
+     *
+     * @throws ModuleException
+     * @throws \Exception
+     */
+    public function testMovedDocumentInheritanceRestriction(FunctionalTester $I)
+    {
+        $group1 = $I->haveAFrontendUserGroup('group-1');
+
+        $document1 = $I->haveAPageDocument('document-1');
+        $document2 = $I->haveAPageDocument('document-2');
+
+        $subDocument = $I->haveASubPageDocument($document1, 'sub-document-1');
+        $subSubDocument = $I->haveASubPageDocument($subDocument, 'sub-sub-document-1');
+
+        $I->addRestrictionToDocument($document1, [$group1->getId()], true, false);
+
+        $I->seeInheritedRestrictionOnEntity($subDocument);
+        $I->seeInheritedRestrictionOnEntity($subSubDocument);
+        $I->moveDocument($subDocument, $document2);
+        $I->seeNoRestrictionOnEntity($subDocument);
+        $I->seeNoRestrictionOnEntity($subSubDocument);
+    }
 }

--- a/tests/functional/Restriction/ObjectRestrictionCest.php
+++ b/tests/functional/Restriction/ObjectRestrictionCest.php
@@ -77,6 +77,79 @@ class ObjectRestrictionCest
     }
 
     /**
+     * @param FunctionalTester $I
+     *
+     * @throws ModuleException
+     * @throws \Exception
+     */
+    public function testObjectInheritanceRestriction(FunctionalTester $I)
+    {
+        $group1 = $I->haveAFrontendUserGroup('group-1');
+        $classDefinition = $I->haveAPimcoreClass('TestClass');
+
+        $object = $I->haveAPimcoreObject($classDefinition->getName(), 'object-1');
+        $subObject = $I->haveASubPimcoreObject($object, $classDefinition->getName(), 'sub-object-1');
+        $subSubObject = $I->haveASubPimcoreObject($subObject, $classDefinition->getName(), 'sub-sub-object-1');
+
+        $I->addRestrictionToObject($object, [$group1->getId()], true, false);
+
+        $I->seeInheritedRestrictionOnEntity($subObject);
+        $I->seeInheritedRestrictionOnEntity($subSubObject);
+        $I->seeRestrictionWithGroupsOnEntity($subObject, [$group1]);
+        $I->seeRestrictionWithGroupsOnEntity($subSubObject, [$group1]);
+
+        $I->changeRestrictionToObject($object, [$group1->getId()], false, false);
+
+        $I->seeRestrictionOnEntity($object);
+        $I->seeNoRestrictionOnEntity($subObject);
+        $I->seeNoRestrictionOnEntity($subSubObject);
+    }
+
+    /**
+     * @param FunctionalTester $I
+     *
+     * @throws ModuleException
+     * @throws \Exception
+     */
+    public function testNewAddedObjectInheritanceRestriction(FunctionalTester $I)
+    {
+        $group1 = $I->haveAFrontendUserGroup('group-1');
+        $classDefinition = $I->haveAPimcoreClass('TestClass');
+
+        $object = $I->haveAPimcoreObject($classDefinition->getName(), 'object-1');
+        $I->addRestrictionToObject($object, [$group1->getId()], true, false);
+
+        $subObject = $I->haveASubPimcoreObject($object, $classDefinition->getName(), 'sub-object-1');
+        $I->seeInheritedRestrictionOnEntity($subObject);
+    }
+
+    /**
+     * @param FunctionalTester $I
+     *
+     * @throws ModuleException
+     * @throws \Exception
+     */
+    public function testMovedObjectInheritanceRestriction(FunctionalTester $I)
+    {
+        $group1 = $I->haveAFrontendUserGroup('group-1');
+        $classDefinition = $I->haveAPimcoreClass('TestClass');
+
+        $object1 = $I->haveAPimcoreObject($classDefinition->getName(), 'object-1');
+        $object2 = $I->haveAPimcoreObject($classDefinition->getName(), 'object-2');
+
+        $subObject = $I->haveASubPimcoreObject($object1, $classDefinition->getName(), 'sub-object-1');
+        $subSubObject = $I->haveASubPimcoreObject($subObject, $classDefinition->getName(), 'sub-sub-object-1');
+
+        $I->addRestrictionToObject($object1, [$group1->getId()], true, false);
+
+        $I->seeInheritedRestrictionOnEntity($subObject);
+        $I->seeInheritedRestrictionOnEntity($subSubObject);
+        $I->moveObject($subObject, $object2);
+        $I->seeNoRestrictionOnEntity($subObject);
+        $I->seeNoRestrictionOnEntity($subSubObject);
+    }
+
+    /**
      * @return string[]
      */
     protected function getStaticRouteConfig()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | /no
| Fixed tickets | #148

This PR introduces 3 new Events:

- `ENTITY_CREATE_RESTRICTION`
- `ENTITY_UPDATE_RESTRICTION`
- `ENTITY_DELETE_RESTRICTION`

I also improved the `POST_UPDATE` move event: If you change the `$entity->setParent()` via API, the restriction service will automatically check/update for oudated/updated restrictions!
