### PR TITLE
Added configuration for custom object keys

### DIFF
--- a/src/MembersBundle/DependencyInjection/Configuration.php
+++ b/src/MembersBundle/DependencyInjection/Configuration.php
@@ -59,6 +59,7 @@ class Configuration implements ConfigurationInterface
                             ->addDefaultsIfNotSet()
                             ->children()
                                 ->scalarNode('class_name')->defaultValue('MembersUser')->end()
+                                ->scalarNode('object_key_form_field')->defaultValue('email')->end()
                             ->end()
                         ->end()
                         ->arrayNode('initial_groups')

--- a/src/MembersBundle/Manager/UserManager.php
+++ b/src/MembersBundle/Manager/UserManager.php
@@ -213,7 +213,9 @@ class UserManager implements UserManagerInterface
         //It's a new user!
         if (empty($user->getKey())) {
             $new = true;
-            $user = $this->setupNewUser($user, null);
+            $userConfig = $this->configuration->getConfig('user');
+            $key = $user->get($userConfig['adapter']['object_key_form_field']);
+            $user = $this->setupNewUser($user, $key);
         }
 
         // update user properties.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #154 

### Description
This PR adds a new config key (`members.user.adapter.object_key_form_field`) which allows the user to define the name of the registration form field, which is being used to set the key of the generated user object.

closes #154 
