### PR TITLE
fix: return proper HTTP response codes on form submit

### DIFF
--- a/src/MembersBundle/Controller/AuthController.php
+++ b/src/MembersBundle/Controller/AuthController.php
@@ -50,13 +50,11 @@ class AuthController extends AbstractController
             $error = null; // The value does not come from the security component.
         }
 
-        $authParams = [
-            'form'          => $form->createView(),
+        return $this->renderForm('@Members/auth/login.html.twig', [
+            'form'          => $form,
             'last_username' => $lastUsername,
             'error'         => $error
-        ];
-
-        return $this->renderTemplate('@Members/auth/login.html.twig', $authParams);
+        ]);
     }
 
     public function checkAction(): void

--- a/src/MembersBundle/Controller/ChangePasswordController.php
+++ b/src/MembersBundle/Controller/ChangePasswordController.php
@@ -67,8 +67,8 @@ class ChangePasswordController extends AbstractController
             return $response;
         }
 
-        return $this->renderTemplate('@Members/change-password/change_password.html.twig', [
-            'form' => $form->createView(),
+        return $this->renderForm('@Members/change-password/change_password.html.twig', [
+            'form' => $form,
         ]);
     }
 }

--- a/src/MembersBundle/Controller/DeleteAccountController.php
+++ b/src/MembersBundle/Controller/DeleteAccountController.php
@@ -66,8 +66,8 @@ class DeleteAccountController extends AbstractController
             return $response;
         }
 
-        return $this->renderTemplate('@Members/delete-account/delete_account.html.twig', [
-            'form' => $form->createView(),
+        return $this->renderForm('@Members/delete-account/delete_account.html.twig', [
+            'form' => $form,
         ]);
     }
 }

--- a/src/MembersBundle/Controller/OAuthController.php
+++ b/src/MembersBundle/Controller/OAuthController.php
@@ -86,8 +86,8 @@ class OAuthController extends AbstractController
             }
         }
 
-        return $this->renderTemplate('@Members/sso/complete-profile/complete_profile.html.twig', [
-            'form' => $form->createView()
+        return $this->renderForm('@Members/sso/complete-profile/complete_profile.html.twig', [
+            'form' => $form
         ]);
     }
 

--- a/src/MembersBundle/Controller/ProfileController.php
+++ b/src/MembersBundle/Controller/ProfileController.php
@@ -84,8 +84,8 @@ class ProfileController extends AbstractController
             return $response;
         }
 
-        return $this->renderTemplate('@Members/profile/edit.html.twig', [
-            'form' => $form->createView(),
+        return $this->renderForm('@Members/profile/edit.html.twig', [
+            'form' => $form,
         ]);
     }
 

--- a/src/MembersBundle/Controller/RegistrationController.php
+++ b/src/MembersBundle/Controller/RegistrationController.php
@@ -84,8 +84,8 @@ class RegistrationController extends AbstractController
             }
         }
 
-        return $this->renderTemplate('@Members/registration/register.html.twig', [
-            'form' => $form->createView()
+        return $this->renderForm('@Members/registration/register.html.twig', [
+            'form' => $form,
         ]);
     }
 

--- a/src/MembersBundle/Controller/ResettingController.php
+++ b/src/MembersBundle/Controller/ResettingController.php
@@ -52,9 +52,9 @@ class ResettingController extends AbstractController
         $form = $this->requestResettingFormFactory->createUnnamedForm();
         $form->handleRequest($request);
 
-        $params = ['form' => $form->createView()];
-
-        return $this->renderTemplate('@Members/resetting/request.html.twig', $params);
+        return $this->renderForm('@Members/resetting/request.html.twig', [
+            'form' => $form,
+        ]);
     }
 
     public function sendEmailAction(Request $request): Response
@@ -161,9 +161,9 @@ class ResettingController extends AbstractController
             return $response;
         }
 
-        return $this->renderTemplate('@Members/resetting/reset.html.twig', [
+        return $this->renderForm('@Members/resetting/reset.html.twig', [
             'token' => $token,
-            'form'  => $form->createView(),
+            'form'  => $form,
         ]);
     }
 }

--- a/src/MembersBundle/Document/Areabrick/MembersLogin/MembersLogin.php
+++ b/src/MembersBundle/Document/Areabrick/MembersLogin/MembersLogin.php
@@ -108,7 +108,7 @@ class MembersLogin extends AbstractAreabrick implements EditableDialogBoxInterfa
             $info->setParam($key, $param);
         }
 
-        return null;
+        return new Response(null, $form->isSubmitted() && !$form->isValid() ? 422 : 200);
     }
 
     public function getTemplate(): string

--- a/src/MembersBundle/Document/Areabrick/MembersLogin/MembersLogin.php
+++ b/src/MembersBundle/Document/Areabrick/MembersLogin/MembersLogin.php
@@ -108,7 +108,7 @@ class MembersLogin extends AbstractAreabrick implements EditableDialogBoxInterfa
             $info->setParam($key, $param);
         }
 
-        return new Response(null, $form->isSubmitted() && !$form->isValid() ? 422 : 200);
+        return null;
     }
 
     public function getTemplate(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

Since Symfony 5.3 there is a new [form handler helper](https://symfony.com/blog/new-in-symfony-5-3-form-handler-helper), which returns the proper HTTP response codes for form submissions. This is especially useful when using libraries like Symfony UX Turbo, as they rely on those in order to reload/redirect the pages correctly.

LMK if anything else needs to be done.
Thanks in advance!