### PR TITLE
Fix the RestrictionQuery to prevent empty results/wrong query

### DIFF
--- a/src/MembersBundle/Security/RestrictionQuery.php
+++ b/src/MembersBundle/Security/RestrictionQuery.php
@@ -50,11 +50,11 @@ class RestrictionQuery
 
         $aliasFrom = $aliasFrom ?? $typedAliasFrom;
 
-        $query->join($aliasFrom, 'members_restrictions', 'mr',
+        $query->leftJoin($aliasFrom, 'members_restrictions', 'mr',
             sprintf('mr.targetId = %s.%s AND mr.ctype = "%s"', $aliasFrom, $queryIdentifier, $cType),
         );
 
-        $query->join($aliasFrom, 'members_group_relations', 'mgr',
+        $query->leftJoin($aliasFrom, 'members_group_relations', 'mgr',
             'mgr.restrictionId = mr.id'
         );
 
@@ -65,7 +65,7 @@ class RestrictionQuery
             $queryStr = sprintf('mr.targetId IS NULL%s', $additionalQuery);
         }
 
-        $query->where($queryStr);
-        $query->groupBy($queryIdentifier);
+        $query->andWhere($queryStr);
+        $query->addGroupBy(sprintf('%s.%s', $aliasFrom, $queryIdentifier));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

### Description
There are basically two things to fix:
- Wrong query (syntax)
- Wrong join behaviour

#### Query
i. The `$queryIdentifier` was set wrong in the Toolbox Bundle (`assets.id` instead of `id`). Therefore the resulting query contained `assets.assets.id` which is a non-existing field.
ii. `$query->where()` and `$query->groupBy()` overrides the conditions/groups which are being applied by Pimcore in the Listing which leads to a parameter mismatch. Using `andWhere()` and `addGroupBy()` fixes that.

#### Join Behaviour
Using `$query->join()` performs an inner join which means that only assets, etc. **with some restrictions defined** appear in the result set. All without any definitions will be cut off.
Using `$query->leftJoin()` keeps also results without restriction-definitions.