### PR TITLE
Fixing a bug where {{ app.user.roles }} is an array or sometimes an object

### DIFF
--- a/src/MembersBundle/Adapter/User/UserTrait.php
+++ b/src/MembersBundle/Adapter/User/UserTrait.php
@@ -71,7 +71,7 @@ trait UserTrait
         // we need to make sure to have at least one role
         $roles[] = static::ROLE_DEFAULT;
 
-        return array_unique($roles);
+        return array_values(array_unique($roles));
     }
 
     public function getGroupNames(): array


### PR DESCRIPTION
strangely this is only the case if the array contains more than 2 values.

To test just output the roles as json ```{{ app.user.roles | json_encode }}```

[see on Stackoverflow](https://stackoverflow.com/questions/17876414/json-encode-after-array-unique-returning-associative-array)
