### PR TITLE
[Protected Asset Downloader] Allow S3 assets to be protected

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,9 @@
 After every update you should check the pimcore extension manager. 
 Just click the "update" button or execute the migration command to finish the bundle update.
 
+#### Update from Version 3.1.5 to Version 3.1.6
+- **[ENHANCEMENT]**: It is now possible to download protected assets from a S3 bucket ([@aarongerig](https://github.com/dachcom-digital/pimcore-members/pull/173))
+
 #### Update from Version 3.1.4 to Version 3.1.5
 - **[ENHANCEMENT]**: You can now define a form field which is later used as object-key in Pimcore, when a user registers ([#154](https://github.com/dachcom-digital/pimcore-members/issues/154))
 

--- a/src/MembersBundle/Controller/RequestController.php
+++ b/src/MembersBundle/Controller/RequestController.php
@@ -109,7 +109,7 @@ class RequestController extends AbstractController
         $response->setCallback(function () use ($asset) {
             flush();
             ob_flush();
-            $handle = fopen(rawurldecode(PIMCORE_ASSET_DIRECTORY . $asset->getFullPath()), 'rb');
+            $handle = fopen($this->getFilePath($asset), 'rb');
             while (!feof($handle)) {
                 echo fread($handle, self::BUFFER_SIZE);
                 flush();
@@ -134,7 +134,7 @@ class RequestController extends AbstractController
 
         /** @var Model\Asset $asset */
         foreach ($assets as $asset) {
-            $filePath = rawurldecode(PIMCORE_ASSET_DIRECTORY . $asset->getFullPath());
+            $filePath = $this->getFilePath($asset);
             $files .= '"' . $filePath . '" ';
         }
 
@@ -166,5 +166,16 @@ class RequestController extends AbstractController
         });
 
         return $response;
+    }
+
+    private function getFilePath(Model\Asset $asset): string
+    {
+        $filePath = $asset->getFullPath();
+
+        if (0 !== \strpos(PIMCORE_ASSET_DIRECTORY, 's3://')) {
+            $filePath = PIMCORE_ASSET_DIRECTORY . $filePath;
+        }
+
+        return \rawurldecode($filePath);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #172

This PR removes the `PIMCORE_ASSET_DIRECTORY` prefix, if the file is served from an S3 bucket. Therefore it will be possible to use assets stored on S3 to be downloaded via the protected asset downloader.