### PR TITLE
fix faulty serialization of role options

### DIFF
--- a/src/CoreExtension/Provider/RoleOptionsProvider.php
+++ b/src/CoreExtension/Provider/RoleOptionsProvider.php
@@ -38,7 +38,7 @@ class RoleOptionsProvider implements SelectOptionsProviderInterface
 
         return array_map(
             static fn ($role): array => ['key' => $role, 'value' => $role],
-            array_unique($roles)
+            array_values(array_unique($roles))
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

When the role options are filtered by the `array_unique` function their indices are preseverd. This leads to faulty serialization while the options are transmitted to the client. The Ext.Js expects an array to populate the multiselect but due to this an object is serialized and returned.  
This PR ensures that the array keys are in numerical order and start at 0 (list instead of associative).