### PR TITLE
Fix: OAuth resource-owner property blacklist never matches camelCase keys

### DIFF
--- a/src/Service/ResourceMappingService.php
+++ b/src/Service/ResourceMappingService.php
@@ -72,7 +72,7 @@ class ResourceMappingService
         }
 
         $ownerDetails = $resourceOwner->toArray();
-        $disallowedProperties = ['lastLogin', 'password', 'confirmationToken', 'passwordRequestedAt', 'groups', 'ssoIdentities'];
+        $disallowedProperties = ['lastlogin', 'password', 'confirmationtoken', 'passwordrequestedat', 'groups', 'ssoidentities'];
 
         foreach ($ownerDetails as $property => $value) {
             if (in_array(strtolower($property), $disallowedProperties)) {


### PR DESCRIPTION
### Bug

`ResourceMappingService::addDefaults()` lower-cases the needle but not the haystack:

```php
$disallowedProperties = ['lastLogin', 'password', 'confirmationToken', 'passwordRequestedAt', 'groups', 'ssoIdentities'];
...
if (in_array(strtolower($property), $disallowedProperties)) { continue; }
```

Only `password` and `groups` (already lowercase) can ever match. `lastLogin`, `confirmationToken`, `passwordRequestedAt` and `ssoIdentities` are **never** filtered. During OAuth login, a resource owner whose `toArray()` contains such a key reaches `setIfEmpty()` → the typed setter is invoked with a provider-supplied value (e.g. `setLastLogin(Carbon)` / `setPasswordRequestedAt(?Carbon)` with a string) → `TypeError`, or a security-relevant field the blacklist was meant to protect gets seeded.

### Fix

Lowercase the blacklist entries so the case-insensitive comparison actually works. No behavior change for the two entries that already matched.
