### PR TITLE
Fix: SSO identity lookup drops the fieldname filter (where() overrides where())

### DIFF
--- a/src/Manager/SsoIdentityManager.php
+++ b/src/Manager/SsoIdentityManager.php
@@ -175,7 +175,7 @@ class SsoIdentityManager implements SsoIdentityManagerInterface
             ->select('src_id')
             ->from('object_relations_' . $userClass::classId())
             ->where('fieldname = :ssoIdentitiesName')
-            ->where('dest_id = :ssoIdentitiesId');
+            ->andWhere('dest_id = :ssoIdentitiesId');
 
         $qb->setParameters([
             'ssoIdentitiesName' => 'ssoIdentities',


### PR DESCRIPTION
### Bug

`SsoIdentityManager::findUserBySsoIdentity()` builds the lookup with two consecutive `->where()` calls:

```php
$qb->select('src_id')
   ->from('object_relations_' . $userClass::classId())
   ->where('fieldname = :ssoIdentitiesName')
   ->where('dest_id = :ssoIdentitiesId');
```

Doctrine DBAL's `QueryBuilder::where()` **replaces** any previously specified restriction, so the `fieldname = :ssoIdentitiesName` condition is dropped and only `dest_id` is filtered (the bound `ssoIdentitiesName` parameter is never used).

If the sso-identity object id happens to be referenced by another relation field of the user class, the query returns more than one row, `count($result) === 1` is false, and the method returns `null` — the owning user is not resolved, breaking SSO login and the token-cleanup user lookup.

### Fix

Use `->andWhere()` for the second condition so both `fieldname` and `dest_id` are applied.
