### PR TITLE
Fix: null dereference in RestrictionUri::getAssetUrlInformation() when asset has no restriction

### DIFF
--- a/src/Security/RestrictionUri.php
+++ b/src/Security/RestrictionUri.php
@@ -104,7 +104,7 @@ class RestrictionUri
             return null;
         }
 
-        $userGroups = $restriction->getRelatedGroups();
+        $userGroups = $restriction instanceof Restriction ? $restriction->getRelatedGroups() : [];
 
         // check if asset is in restricted mode without any restriction settings
         // if not, set restriction to null since there can't be any protection.


### PR DESCRIPTION
### Bug

In `RestrictionUri::getAssetUrlInformation()`:

```php
try {
    $restriction = Restriction::getByTargetId($assetId, 'asset');
} catch (\Exception $e) {
    return null;
}

$userGroups = $restriction->getRelatedGroups();
```

`Restriction::getByTargetId()` returns **null** (not a thrown exception) when there is no restriction row for the asset — the common case of an asset in a protected folder without an explicit restriction record. `$restriction->getRelatedGroups()` then throws `\Error`, which is **not** caught by the `catch (\Exception)` above (Error is not an Exception), so it surfaces as an uncaught fatal.

### Fix

Guard the null case (no restriction → no related groups), consistent with the "restricted mode without any restriction settings → empty groups" handling immediately below.
